### PR TITLE
Final fix for parsing result of test incorrectly.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -96,7 +96,7 @@ function terraform-opa-run() {
   echo ""
 
   # Fail the pipeline step entirely if the option is enabled to enforce that behavior.
-  if [[ ${OPA_PASS} == "false" ]]; then
+if [[ $(echo ${OPA_PASS} | jq) == false ]]; then
     if [[ "${FAIL_STEP}" == true ]]; then
       echo -e "${cRed}[!] Terraform plan does not meet the policy requirements.${cNone}"
       exit 1

--- a/hooks/command
+++ b/hooks/command
@@ -96,7 +96,7 @@ function terraform-opa-run() {
   echo ""
 
   # Fail the pipeline step entirely if the option is enabled to enforce that behavior.
-if [[ $(echo ${OPA_PASS} | jq) == false ]]; then
+  if [[ $(echo ${OPA_PASS} | jq) == false ]]; then
     if [[ "${FAIL_STEP}" == true ]]; then
       echo -e "${cRed}[!] Terraform plan does not meet the policy requirements.${cNone}"
       exit 1

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,6 +3,7 @@ description: Runs Open Policy Agent against Terraform plans.
 author: https://github.com/echoboomer
 requirements:
   - docker
+  - jq
 configuration:
   properties:
     debug:


### PR DESCRIPTION
Output from `opa` is `json` by default so there was a small issue with getting it to format properly for evaluation in the end of the script. This fixes that.