### PR TITLE
Adds ability to skip running on master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ If this is provided and set to `true`, the Buildkite pipeline will fail if the p
 
 The Docker image to run for Open Policy Agent. Defaults to `openpolicyagent/opa`. The `version` option specified below correlates with the `tag` option.
 
+### `skip_master_branch` (Not Required, boolean)
+
+If this is provided and set to `true`, the plugin looks for `BUILDKITE_BRANCH` and won't run if the value is `master`. This is useful is the plugin runs alongside others in one step using the example above.
+
 ### `tests_dir` (Not Required, string)
 
 The path of the directory in your Terraform repository containing the required files for running Open Policy Agent assessments against Terraform code. Since Buildkite agents typically operate from the root of a repository, this is in relation to that top level path. This defaults to `./terraform/tests`. You may override this as long as your files are available in the given location.

--- a/hooks/command
+++ b/hooks/command
@@ -6,6 +6,7 @@ cNone="\033[00m"
 cRed="\033[01;31m"
 cGreen="\033[01;32m"
 
+BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-}
 IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_OPA_IMAGE:-"openpolicyagent/opa"}
 VERSION=${BUILDKITE_PLUGIN_TERRAFORM_OPA_VERSION:-"latest"}
 OPA_IMAGE="${IMAGE_NAME}:${VERSION}"
@@ -28,6 +29,7 @@ function terraform-opa-run() {
   local POLICY_FILE=${BUILDKITE_PLUGIN_TERRAFORM_OPA_POLICY_FILE:-"${TESTS_DIR}/terraform.rego"}
   local RESOURCE_TYPES_FILE=${BUILDKITE_PLUGIN_TERRAFORM_OPA_RESOURCE_TYPES_FILE:-"${TESTS_DIR}/resource_types.json"}
   local RESOURCE_WEIGHTS_FILE=${BUILDKITE_PLUGIN_TERRAFORM_OPA_RESOURCE_WEIGHTS_FILE:-"${TESTS_DIR}/resource_weights.json"}
+  local SKIP_MASTER_BRANCH=${BUILDKITE_PLUGIN_TERRAFORM_OPA_SKIP_MASTER_BRANCH:-false}
   local TERRAFORM_PLAN=${BUILDKITE_PLUGIN_TERRAFORM_OPA_TERRAFORM_PLAN}
 
   if [[ "${DEBUG}" == true ]]; then
@@ -112,4 +114,8 @@ function terraform-opa-run() {
   echo ""
 }
 
-terraform-opa-run
+if [[ "${SKIP_MASTER_BRANCH}" == true && "${BUILDKITE_BRANCH}" == "master" ]]; then
+  exit 0
+else
+  terraform-opa-run
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -12,6 +12,8 @@ configuration:
       type: boolean
     image:
       type: string
+    skip_master_branch:
+      type: boolean
     policy_file:
       type: string
     resource_types_file:


### PR DESCRIPTION
When using the plugin in the same step as a Terraform plan/apply operation, it's useful to disable running it but only for the master branch. This adds that feature and updates docs.